### PR TITLE
Add --pure-lockfile to CI yarn deps install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           - deps-{{ checksum "package.json" }}-
           - deps-
 
-      - run: yarn install
+      - run: yarn install --pure-lockfile
 
       - save_cache:
           paths:


### PR DESCRIPTION
Using --pure-lockfile guarantees consistency.