### PR TITLE
Prevent undefined errors in string manipulating methods and functions

### DIFF
--- a/specs/datasource.spec.ts
+++ b/specs/datasource.spec.ts
@@ -119,6 +119,12 @@ describe('VividCortex datasource', () => {
 
       expect(replaceSpy.lastCall.args[0]).to.equal(metric);
     });
+
+    it('should not fail when given an undefined metric', () => {
+      const metric = undefined;
+
+      expect(datasource.interpolateVariables(metric)).to.equal('');
+    });
   });
 
   describe('#doRequest()', () => {
@@ -170,6 +176,10 @@ describe('VividCortex datasource', () => {
       const expectedOutput = 'host.queries.q.c0f33.tput,host.queries.q.c0f33.tput';
 
       expect(datasource.transformMetricForQuery(input)).to.equal(expectedOutput);
+    });
+
+    it('should not fail when given an undefined metric', () => {
+      expect(datasource.transformMetricForQuery(undefined)).to.equal('');
     });
   });
 

--- a/specs/host_filter.parse.spec.ts
+++ b/specs/host_filter.parse.spec.ts
@@ -20,6 +20,20 @@ describe('Filter parser', () => {
     ]);
   });
 
+  it('should not fail with undefined configuration', () => {
+    const result = parseFilters(undefined);
+
+    expect(result).to.be.an('array');
+
+    expect(parseSpy.threw()).to.be.false;
+    expect(result).to.deep.equal([
+      {
+        type: 'substring',
+        value: '',
+      },
+    ]);
+  });
+
   describe('Key=value filters', () => {
     it('should parse a key=value filter', () => {
       const result = parseFilters('type=os');

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -120,7 +120,7 @@ export default class VividCortexDatasource {
    * @param  {string} metric
    * @return {string}
    */
-  interpolateVariables(metric: string) {
+  interpolateVariables(metric: string = '') {
     return this.templateSrv.replace(metric, null, 'regex').replace(/\\\./g, '.');
   }
 
@@ -168,7 +168,7 @@ export default class VividCortexDatasource {
    * @param  {string} metric
    * @return {string}
    */
-  transformMetricForQuery(metric: string) {
+  transformMetricForQuery(metric: string = '') {
     const metrics = metric.replace(/[()]/g, '').split('|');
 
     if (metrics.length < 2) {

--- a/src/lib/host_filter.ts
+++ b/src/lib/host_filter.ts
@@ -5,7 +5,7 @@
  * @return {Array}
  */
 
-function parseFilters(config: string) {
+function parseFilters(config: string = '') {
   const rawFilters = config.split(' ');
 
   return rawFilters.map(filter => {


### PR DESCRIPTION
The functions that manipulate strings may receive `undefined` values, which shouldn't trigger errors or exceptions.