### PR TITLE
Improve metric selection and autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "VividCortex",
   "license": "MIT",
   "dependencies": {
+    "lodash": "^4.17.10",
     "moment": "^2.22.0",
     "q": "^1.5.1",
     "systemjs": "^0.21.1"

--- a/specs/datasource.spec.ts
+++ b/specs/datasource.spec.ts
@@ -69,9 +69,19 @@ describe('VividCortex datasource', () => {
         });
 
         expect(datasourceRequestSpy.lastCall.args[0].method).to.equal('GET');
-        expect(datasourceRequestSpy.lastCall.args[0].url).to.equal(config.apiUrl + 'metrics/search');
+        expect(datasourceRequestSpy.lastCall.args[0].url).to.equal(config.apiUrl + 'metrics');
         expect(datasourceRequestSpy.lastCall.args[0].data).to.deep.equal({});
-        expect(datasourceRequestSpy.lastCall.args[0].params).to.deep.equal({ q: 'host.' });
+        expect(datasourceRequestSpy.lastCall.args[0].params['new']).to.equal('0');
+        expect(datasourceRequestSpy.lastCall.args[0].params['filter']).to.equal('*host.*');
+
+        done();
+      });
+    });
+
+    it('should not filter and get all the metrics by default', done => {
+      datasource.metricFindQuery('').then(response => {
+        expect(response).to.have.lengthOf(11);
+        expect(datasourceRequestSpy.lastCall.args[0].params['filter']).to.equal(undefined);
 
         done();
       });
@@ -108,6 +118,16 @@ describe('VividCortex datasource', () => {
         expect(doQuerySpy.callCount).to.equal(2);
 
         expect(response.data).to.have.lengthOf(2);
+
+        done();
+      });
+    });
+  });
+
+  describe('#getActiveHosts', () => {
+    it('should retrieve the active hosts in a time interval', done => {
+      datasource.getActiveHosts(123456789, 987654321).then(response => {
+        expect(response).to.have.lengthOf(1);
 
         done();
       });

--- a/specs/lib/mocks.ts
+++ b/specs/lib/mocks.ts
@@ -18,6 +18,21 @@ const backendSrv = {
       metrics: {
         success: {
           status: 200,
+          data: {
+            data: [
+              { name: 'host.auth', firstSeen: 1508354400, lastSeen: 1527698640 },
+              { name: 'host.callers', firstSeen: 1508354400, lastSeen: 1527698640 },
+              { name: 'host.connections', firstSeen: 1508354400, lastSeen: 1527698640 },
+              { name: 'host.dbs', firstSeen: 1508354400, lastSeen: 1527698640 },
+              { name: 'host.queries', firstSeen: 1508354400, lastSeen: 1527698640 },
+              { name: 'host.samples', firstSeen: 1508354400, lastSeen: 1527698640 },
+              { name: 'host.status', firstSeen: 1508354400, lastSeen: 1527698640 },
+              { name: 'host.tables', firstSeen: 1508354400, lastSeen: 1527698640 },
+              { name: 'host.totals', firstSeen: 1508354400, lastSeen: 1527698640 },
+              { name: 'host.users', firstSeen: 1508354400, lastSeen: 1527698640 },
+              { name: 'host.verbs', firstSeen: 1508354400, lastSeen: 1527698640 },
+            ],
+          },
         },
         error: {
           status: 500,

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -91,9 +91,11 @@ export default class VividCortexDatasource {
   }
 
   /* Custom methods ----------------------------------------------------------------------------- */
-  refreshHostsForMetrics() {
-    console.log('Refreshing active hosts for metrics query');
 
+  /**
+   * Load the host list to use for the metric find query.
+   */
+  refreshHostsForMetrics() {
     const params = {
       from: moment()
         .utc()

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,7 +1,9 @@
 ///<reference path='../node_modules/grafana-sdk-mocks/app/headers/common.d.ts' />
-import moment from 'moment';
+import * as moment from 'moment';
 import { parseFilters, testHost } from './lib/host_filter';
 import { calculateSampleSize } from './lib/helpers';
+
+const momentjs = moment.default ? moment.default : moment;
 
 export default class VividCortexDatasource {
   private apiToken: string;
@@ -50,11 +52,11 @@ export default class VividCortexDatasource {
 
   metricFindQuery(query: string) {
     const params = {
-      from: moment()
+      from: momentjs()
         .utc()
         .subtract(7, 'days')
         .unix(),
-      until: moment()
+      until: momentjs()
         .utc()
         .unix(),
       new: '0',

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -8,7 +8,6 @@ export default class VividCortexDatasource {
   private backendSrv;
   private templateSrv;
   private $q;
-  private metricsHosts = [];
 
   /** @ngInject */
   constructor(instanceSettings, backendSrv, templateSrv, $q) {
@@ -17,8 +16,6 @@ export default class VividCortexDatasource {
     this.$q = $q;
 
     this.apiToken = instanceSettings.jsonData.apiToken;
-
-    this.refreshHostsForMetrics();
   }
 
   testDatasource() {
@@ -60,7 +57,6 @@ export default class VividCortexDatasource {
       until: moment()
         .utc()
         .unix(),
-      host: '0,' + this.metricsHosts.map(host => host.id).join(','),
       new: '0',
       filter: query ? `*${query}*` : undefined,
     };
@@ -91,23 +87,6 @@ export default class VividCortexDatasource {
   }
 
   /* Custom methods ----------------------------------------------------------------------------- */
-
-  /**
-   * Load the host list to use for the metric find query.
-   */
-  refreshHostsForMetrics() {
-    const params = {
-      from: moment()
-        .utc()
-        .subtract(7, 'days')
-        .unix(),
-      until: moment()
-        .utc()
-        .unix(),
-    };
-
-    this.getActiveHosts(params.from, params.until).then(hosts => (this.metricsHosts = hosts));
-  }
 
   /**
    * Get the active hosts in a time interval.

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -16,8 +16,6 @@ export class VividCortexQueryCtrl extends QueryCtrl {
     this.target.target = this.target.target || 'select metric';
     this.target.type = this.target.type || 'timeserie';
 
-    this.datasource.refreshHostsForMetrics();
-
     this.debouncedMetricFind = _.debounce(this.datasource.metricFindQuery.bind(this.datasource), 250);
   }
 

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -1,10 +1,13 @@
 ///<reference path="../node_modules/grafana-sdk-mocks/app/headers/common.d.ts" />
 
 import { QueryCtrl } from 'app/plugins/sdk';
+import _ from 'lodash';
 import './css/query_editor.css!';
 
 export class VividCortexQueryCtrl extends QueryCtrl {
   static templateUrl = 'partials/query.editor.html';
+
+  private debouncedMetricFind;
 
   /** @ngInject **/
   constructor($scope, $injector) {
@@ -14,13 +17,15 @@ export class VividCortexQueryCtrl extends QueryCtrl {
     this.target.type = this.target.type || 'timeserie';
 
     this.datasource.refreshHostsForMetrics();
+
+    this.debouncedMetricFind = _.debounce(this.datasource.metricFindQuery.bind(this.datasource), 250);
   }
 
   getOptions(query) {
-    return this.datasource.metricFindQuery(query || '');
+    return this.debouncedMetricFind(query);
   }
 
   onChangeInternal() {
-    this.panelCtrl.refresh(); // Asks the panel to refresh data.
+    this.panelCtrl.refresh();
   }
 }

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -14,7 +14,7 @@ export class VividCortexQueryCtrl extends QueryCtrl {
     super($scope, $injector);
 
     this.target.target = this.target.target || 'select metric';
-    this.target.type = this.target.type || 'timeserie';
+    this.target.type = this.target.type || 'timeseries';
 
     this.debouncedMetricFind = _.debounce(this.datasource.metricFindQuery.bind(this.datasource), 250);
   }

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -6,14 +6,14 @@ import './css/query_editor.css!';
 export class VividCortexQueryCtrl extends QueryCtrl {
   static templateUrl = 'partials/query.editor.html';
 
-  defaults = {};
-
   /** @ngInject **/
   constructor($scope, $injector) {
     super($scope, $injector);
 
     this.target.target = this.target.target || 'select metric';
     this.target.type = this.target.type || 'timeserie';
+
+    this.datasource.refreshHostsForMetrics();
   }
 
   getOptions(query) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "target": "ES5",
+    "module": "commonjs",
     "sourceMap": true,
     "declaration": true,
     "emitDecoratorMetadata": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2103,6 +2103,10 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
+lodash@^4.17.10:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
 lodash@^4.17.4, lodash@^4.3.0, lodash@~4.17.4, lodash@~4.17.5:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"


### PR DESCRIPTION
In this PR we:
- Change the endpoint used to get and autocomplete metric names.
- Improve the perceived performance of the autocompleted field.
- Remove the need to make as many `/host` as `/metrics` calls.
- Debounced the `metricFindQuery` call to prevent unnecessary requests as the user types.