### PR TITLE
Add ability to graph hosts separately on same chart

### DIFF
--- a/specs/datasource.spec.ts
+++ b/specs/datasource.spec.ts
@@ -10,11 +10,12 @@ const config = require('../src/config.json');
 const datasourceRequestSpy = sinon.spy(backendSrv, 'datasourceRequest');
 const replaceSpy = sinon.spy(templateSrv, 'replace');
 
-let datasource, errorDatasource;
+let datasource, failureDatasource, errorDatasource;
 
 describe('VividCortex datasource', () => {
   beforeEach(() => {
     datasource = new VividCortexDatasource({ jsonData: { apiToken: 'success' } }, backendSrv, templateSrv, $q);
+    failureDatasource = new VividCortexDatasource({ jsonData: { apiToken: 'failure' } }, backendSrv, templateSrv, $q);
     errorDatasource = new VividCortexDatasource({ jsonData: { apiToken: 'error' } }, backendSrv, templateSrv, $q);
   });
 
@@ -39,9 +40,22 @@ describe('VividCortex datasource', () => {
       });
     });
 
-    it('should let the user know the datasource configuration failed', done => {
-      errorDatasource.testDatasource().then(response => {
+    it('should let the user there was an error with the datasource verification', done => {
+      failureDatasource.testDatasource().then(response => {
         expect(response).to.deep.equal({
+          status: 'error',
+          message:
+            'The configuration test was not successful. Pleaes check your API token and Internet access and try again.',
+          title: 'Credentials error',
+        });
+
+        done();
+      });
+    });
+
+    it('should let the user know the datasource configuration failed', done => {
+      errorDatasource.testDatasource().then(error => {
+        expect(error).to.deep.equal({
           status: 'error',
           message:
             'The configuration test was not successful. Pleaes check your API token and Internet access and try again.',
@@ -98,12 +112,13 @@ describe('VividCortex datasource', () => {
     });
 
     it('should perform as many API requests as configured targets', done => {
-      const doQuerySpy = sinon.spy(datasource, 'doQuery');
+      const doQuerySpy = sinon.spy(datasource, 'doQuery'),
+        doRequestSpy = sinon.spy(datasource, 'doRequest');
 
       const options = {
         targets: [
-          { target: 'host.queries.*.*.tput', hosts: 'type=mysql' },
-          { target: 'host.queries.*.*.t_us', hosts: 'type=mysql' },
+          { target: 'host.queries.*.*.tput', hosts: 'type=mysql', separateHosts: 1 },
+          { target: 'host.queries.*.*.t_us', hosts: 'type=mysql', separateHosts: 0 },
         ],
         range: {
           from: { unix: () => 123456789, utc: sinon.spy() },
@@ -116,6 +131,8 @@ describe('VividCortex datasource', () => {
         expect(options.range.to.utc.called).to.be.true;
 
         expect(doQuerySpy.callCount).to.equal(2);
+
+        expect(doRequestSpy.callCount).to.equal(4);
 
         expect(response.data).to.have.lengthOf(2);
 
@@ -208,11 +225,11 @@ describe('VividCortex datasource', () => {
 
   describe('#mapQueryResponse()', () => {
     it('should return an empty array if no data was provided', () => {
-      expect(datasource.mapQueryResponse([], 123456789, 987654321)).to.deep.equal({ data: [] });
-      expect(datasource.mapQueryResponse([{ elements: [] }], 123456789, 987654321)).to.deep.equal({ data: [] });
+      expect(datasource.mapQueryResponse([], [], 123456789, 987654321)).to.deep.equal({ data: [] });
+      expect(datasource.mapQueryResponse([{ elements: [] }], [], 123456789, 987654321)).to.deep.equal({ data: [] });
     });
 
-    it('should return an empty array if no data was provided', () => {
+    it('should return an array with the expected format', () => {
       const input = [
         {
           elements: [
@@ -245,7 +262,78 @@ describe('VividCortex datasource', () => {
         ],
       };
 
-      expect(datasource.mapQueryResponse(input, 123456789, 987654321)).to.deep.equal(expectedOutput);
+      expect(datasource.mapQueryResponse(input, [], 123456789, 987654321)).to.deep.equal(expectedOutput);
+    });
+
+    it('should use the host name as the metric when separating by host', () => {
+      const hosts = [
+        {
+          id: 1,
+          name: 'Host 1',
+        },
+        {
+          id: 2,
+          name: 'Host 2',
+        },
+      ];
+
+      const input = [
+        {
+          elements: [
+            {
+              metric: 'host.queries.q.c0f33b4c0n.tput',
+              host: 1,
+              series: [0, 1, 0],
+            },
+          ],
+        },
+        {
+          elements: [
+            {
+              host: 2,
+              metric: 'host.queries.q.b33fav0c4d0.tput',
+              series: [0, 0, 1],
+            },
+          ],
+        },
+      ];
+
+      const expectedOutput = {
+        data: [
+          {
+            target: 'Host 1',
+            datapoints: [[0, 123456789000], [1, 411522633000], [0, 699588477000]],
+          },
+          {
+            target: 'Host 2',
+            datapoints: [[0, 123456789000], [0, 411522633000], [1, 699588477000]],
+          },
+        ],
+      };
+
+      expect(datasource.mapQueryResponse(input, hosts, 123456789, 987654321)).to.deep.equal(expectedOutput);
+    });
+  });
+
+  describe('#getTargetNameFromSeries()', () => {
+    it('should return the metric name if a host is not in the answer', () => {
+      const series = { metric: 'os.cpu.loadavg' };
+
+      expect(datasource.getTargetNameFromSeries(series, [])).to.equal('os.cpu.loadavg');
+    });
+
+    it('should return the host name if a host id is in the answer', () => {
+      const series = { metric: 'os.cpu.loadavg', host: 1 };
+      const hosts = [{ id: 0, name: 'Not me' }, { id: 1, name: 'Host 1' }, { id: 3, name: 'Me neither' }];
+
+      expect(datasource.getTargetNameFromSeries(series, hosts)).to.equal('Host 1');
+    });
+
+    it('should not fail if the host was not found by id', () => {
+      const series = { metric: 'os.cpu.loadavg', host: 4 };
+      const hosts = [{ id: 0, name: 'Not me' }, { id: 1, name: 'Host 1' }, { id: 3, name: 'Me neither' }];
+
+      expect(datasource.getTargetNameFromSeries(series, hosts)).to.equal('Unknown host');
     });
   });
 });

--- a/specs/host_filter.test.spec.ts
+++ b/specs/host_filter.test.spec.ts
@@ -18,6 +18,13 @@ describe('Host filter', () => {
     expect(result).to.have.lengthOf(3);
   });
 
+  it('should return the previous evaluated value when processing an unknown filter', () => {
+    const fakeFilters = [{ type: 'nonexisting' }],
+      result = hosts.filter(host => testHost(host, fakeFilters));
+
+    expect(result).to.have.lengthOf(3);
+  });
+
   describe('Key=value filters', () => {
     it('should filter the hosts by type', () => {
       const config = 'type=mysql',

--- a/specs/lib/mocks.ts
+++ b/specs/lib/mocks.ts
@@ -34,9 +34,10 @@ const backendSrv = {
             ],
           },
         },
-        error: {
-          status: 500,
+        failure: {
+          status: 401,
         },
+        error: new Error('Internal server error'),
       },
       'metrics/search': {
         success: {
@@ -92,6 +93,12 @@ const backendSrv = {
 
     if (!response) {
       console.error('Backend request mock not found.');
+    } else if (response instanceof Error) {
+      const defer = $q.defer();
+
+      defer.reject(response);
+
+      return defer.promise;
     }
 
     return $q.when(response || {});

--- a/src/css/query_editor.css
+++ b/src/css/query_editor.css
@@ -18,6 +18,10 @@
   right: 0.775rem;
 }
 
+.vc-host-filter__container {
+  position: relative;
+}
+
 .vc-learn-more__link {
   text-decoration: underline;
 }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -121,7 +121,7 @@ export default class VividCortexDatasource {
       samplesize: calculateSampleSize(from, until, dataPoints),
       until: until,
       host: null,
-      separateHosts: target.separateHosts ? '1' : '0',
+      separateHosts: target.separateHosts ? 1 : 0,
     };
 
     const body = {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -121,6 +121,7 @@ export default class VividCortexDatasource {
       samplesize: calculateSampleSize(from, until, dataPoints),
       until: until,
       host: null,
+      separateHosts: target.separateHosts ? '1' : '0',
     };
 
     const body = {
@@ -130,9 +131,9 @@ export default class VividCortexDatasource {
     const defer = this.$q.defer();
 
     this.getActiveHosts(params.from, params.until).then(hosts => {
-      params.host = this.filterHosts(hosts, target.hosts)
-        .map(host => host.id)
-        .join(',');
+      const filteredHosts = this.filterHosts(hosts, target.hosts);
+
+      params.host = filteredHosts.map(host => host.id).join(',');
 
       this.doRequest('metrics/query-series', 'POST', params, body)
         .then(response => ({
@@ -141,7 +142,7 @@ export default class VividCortexDatasource {
           until: parseInt(response.headers('X-Vc-Meta-Until')),
         }))
         .then(response => {
-          defer.resolve(this.mapQueryResponse(response.metrics, response.from, response.until));
+          defer.resolve(this.mapQueryResponse(response.metrics, filteredHosts, response.from, response.until));
         })
         .catch(error => {
           defer.reject(error);
@@ -219,11 +220,12 @@ export default class VividCortexDatasource {
    * Map a VividCortex series response to Grafana's structure.
    *
    * @param  {Array} series
+   * @param  {Array} hosts
    * @param  {number} from
    * @param  {number} until
    * @return {Array}
    */
-  mapQueryResponse(series: Array<any>, from: number, until: number) {
+  mapQueryResponse(series: Array<any>, hosts: Array<any>, from: number, until: number) {
     if (!series.length || !series[0].elements.length) {
       return { data: [] };
     }
@@ -238,7 +240,7 @@ export default class VividCortexDatasource {
         const sampleSize = (until - from) / values.length;
 
         response.data.push({
-          target: element.metric,
+          target: this.getTargetNameFromSeries(element, hosts),
           datapoints: values.map((value, index) => {
             return [value, (from + index * sampleSize) * 1e3];
           }),
@@ -247,5 +249,23 @@ export default class VividCortexDatasource {
     });
 
     return response;
+  }
+
+  /**
+   * From a time series response, return the appropiate label to identify the target in the graph.
+   * When the response is divided by host, we use the host name, otherwise the metric name.
+   *
+   * @param  {Object} series description
+   * @param  {Array} series description
+   * @return {string}        description
+   */
+  getTargetNameFromSeries(series, hosts: Array<any>) {
+    if (!series.host) {
+      return series.metric;
+    }
+
+    const host = hosts.filter(host => host.id === series.host);
+
+    return host.length ? host[0].name : 'Unknown host';
   }
 }

--- a/src/lib/host_filter.ts
+++ b/src/lib/host_filter.ts
@@ -77,9 +77,8 @@ function testHost(host: any, filters: Array<any>) {
       case 'substring':
         return host.name.indexOf(filter.value) >= 0;
       case 'exclude':
-        return true;
       default:
-        return included;
+        return true;
     }
   }, false);
 }

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -1,10 +1,10 @@
-<div>
-  <p>
-    <a class="vc-learn-more__link" target="_blank" rel="noopener" href="https://docs.vividcortex.com/general-reference/metric-categories/">Learn more</a>
-    about VividCortex metric categories and how to use them.
-  </p>
-</div>
 <query-editor-row query-ctrl="ctrl" can-collapse="false">
+  <div>
+    <p>
+      <a class="vc-learn-more__link" target="_blank" rel="noopener" href="https://docs.vividcortex.com/general-reference/metric-categories/">Learn more</a>
+      about VividCortex metric categories and how to use them.
+    </p>
+  </div>
   <div class="gf-form-group">
     <div class="gf-form-inline">
       <div class="gf-form">
@@ -21,16 +21,25 @@
           on-change="ctrl.onChangeInternal()">
         </gf-form-dropdown>
 
-        <input class="gf-form-input width-30" type="text" ng-model="ctrl.target.hosts" placeholder="Filter your hosts by name or type" />
+        <div class="vc-host-filter__container">
+          <input class="gf-form-input width-30" type="text" ng-model="ctrl.target.hosts" placeholder="Filter your hosts by name or type"/>
 
-        <info-popover mode="right-absolute">
-            <ul>
-              <li>By default, if you type <em>api</em>, any host whose name includes the substring api will become part of the set of active hosts. </li>
-              <li>You can match hostnames exactly by wrapping them with the double quotes sign. The string <em>"api2"</em>, for example, will match a host named <em>api2</em> but not one named <em>api20</em>.</li>
-              <li>You can exclude hosts from the selection by negating them with a minus sign. For example, <em>-"api20"</em>.</li>
-              <li>You can select hosts by their type (os, mysql, pgsql, redis and mongo at present), with syntax such as <em>type=os</em> or <em>type=mysql</em>.</li>
-            </ul>
-        </info-popover>
+          <info-popover mode="right-absolute">
+              <ul>
+                <li>By default, if you type <em>api</em>, any host whose name includes the substring api will become part of the set of active hosts. </li>
+                <li>You can match hostnames exactly by wrapping them with the double quotes sign. The string <em>"api2"</em>, for example, will match a host named <em>api2</em> but not one named <em>api20</em>.</li>
+                <li>You can exclude hosts from the selection by negating them with a minus sign. For example, <em>-"api20"</em>.</li>
+                <li>You can select hosts by their type (os, mysql, pgsql, redis and mongo at present), with syntax such as <em>type=os</em> or <em>type=mysql</em>.</li>
+              </ul>
+          </info-popover>
+        </div>
+
+        <gf-form-switch class="gf-form" label="Separate results by host" label-class="width-12" checked="ctrl.target.separateHosts" on-change="ctrl.onChangeInternal()">
+          <div class="gf-form-switch" ng-if="ctrl.target.separateHosts">
+            <input id="vc-separate-hosts" type="checkbox" ng-model="ctrl.target.separateHosts">
+            <label for="vc-separate-hosts" data-on="1" data-off="0"></label>
+          </div>
+        </gf-form-switch>
       </div>
       <div class="gf-form gf-form--grow">
         <div class="gf-form-label gf-form-label--grow"></div>


### PR DESCRIPTION
A new configuration option was added, allowing to enable or disable the separation of the time series by host.

Option:
![option](https://user-images.githubusercontent.com/1069378/40857156-b1801f5e-65b0-11e8-8f8f-89342b832228.png)

Demo:
![demo](https://dzwonsemrish7.cloudfront.net/items/2s2D3F1f1b0c0E2V0V2x/Screen%20Recording%202018-06-01%20at%2003.01%20p.%20m..gif?v=3994182c)