### PR TITLE
Improve autocomplete performance

### DIFF
--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -1,10 +1,11 @@
+<div>
+  <p>
+    <a class="vc-learn-more__link" target="_blank" rel="noopener" href="https://docs.vividcortex.com/general-reference/metric-categories/">Learn more</a>
+    about VividCortex metric categories and how to use them.
+  </p>
+</div>
+
 <query-editor-row query-ctrl="ctrl" can-collapse="false">
-  <div>
-    <p>
-      <a class="vc-learn-more__link" target="_blank" rel="noopener" href="https://docs.vividcortex.com/general-reference/metric-categories/">Learn more</a>
-      about VividCortex metric categories and how to use them.
-    </p>
-  </div>
   <div class="gf-form-group">
     <div class="gf-form-inline">
       <div class="gf-form">

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -8,7 +8,6 @@ export class VividCortexQueryCtrl extends QueryCtrl {
 
   public loading;
 
-  private metricFindDefer;
   private metricFindTimeout;
   private $q;
   private $timeout;
@@ -25,28 +24,28 @@ export class VividCortexQueryCtrl extends QueryCtrl {
   }
 
   getOptions(query) {
-    if (!this.metricFindDefer) {
-      this.metricFindDefer = this.$q.defer();
-    }
+    const defer = this.$q.defer();
 
     this.loading = true;
 
-    this.$timeout.cancel(this.metricFindTimeout);
+    if (this.metricFindTimeout) {
+      this.$timeout.cancel(this.metricFindTimeout);
+    }
 
     this.metricFindTimeout = this.$timeout(() => {
       this.datasource
         .metricFindQuery(query)
         .then(metrics => {
-          this.metricFindDefer.resolve(metrics);
+          defer.resolve(metrics);
         })
-        .catch(error => this.metricFindDefer.reject(error))
+        .catch(error => defer.reject(error))
         .finally(() => {
-          this.metricFindDefer = null;
+          this.metricFindTimeout = null;
           this.loading = false;
         });
     }, 250);
 
-    return this.metricFindDefer.promise;
+    return defer.promise;
   }
 
   onChangeInternal() {


### PR DESCRIPTION
- Use the last 24 hours as the time frame to request metrics
- Limit the response to 10 results
- Improve the behavior of the query editor metric find debouce